### PR TITLE
fix moj_elektro sensor name

### DIFF
--- a/15min_interval_input.yaml
+++ b/15min_interval_input.yaml
@@ -83,7 +83,7 @@ color_list:
   - var(--paper-item-icon-active-color)
 
 series:
-  - entity: sensor.mojelektro_15min_input
+  - entity: sensor.moj_elektro_15min_input
     name: 15 min interval
     type: column
     float_precision: 3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apex Chart Card example
 An example code for using Apex Chart Card in Home Assistant Lovelance UI.
 
-![Screenshot of a Moj Electro in Home Assistant using Apex Chart Card.](https://github.com/frlequ/homeassistant-mojelektro/blob/main/assets/energy.jpg)
+![Screenshot of a Moj Electro in Home Assistant using Apex Chart Card.](https://github.com/frlequ/homeassistant-moj_elektro/blob/main/assets/energy.jpg)
 
 ## Usage
 1. Install card: [Apex Chart card](https://github.com/RomRider/apexcharts-card)

--- a/daily_total_VT_MT.yaml
+++ b/daily_total_VT_MT.yaml
@@ -101,7 +101,7 @@ color_list:
   - var(--paper-item-icon-active-color)
 update_interval: 1hour
 series:
-  - entity: sensor.mojelektro_daily_input_peak
+  - entity: sensor.moj_elektro_daily_input_peak
     name: VT
     type: column
     float_precision: 2
@@ -113,7 +113,7 @@ series:
       period: day
       align: start
     offset: +1day
-  - entity: sensor.mojelektro_daily_input_offpeak
+  - entity: sensor.moj_elektro_daily_input_offpeak
     name: MT
     type: column
     float_precision: 2


### PR DESCRIPTION
This pull request updates the sensor names in the charts to align with the [homeassistant-mojelektro](https://github.com/frlequ/homeassistant-mojelektro) integration's default naming convention. Previously, the charts used "sensor.mojelektro" instead of the correct default name, "sensor.moj_elektro".